### PR TITLE
Fix quoting in report reason message

### DIFF
--- a/app.py
+++ b/app.py
@@ -490,7 +490,7 @@ async def print_report(payload: Dict):
             sug_path = routing.get("selected_path") or routing.get("suggested_path") or ""
             print(f"path:   NEEDS NEW → {sug_path}  (conf={routing.get('confidence')})")
         if routing.get("reason"):
-            print(f"reason: {routing.get("reason")}")
+            print(f"reason: {routing.get('reason')}")
     print("\n-- SUMMARY (RU) --")
     print(sums.get('ru',""))
     print("\n-- SUMMARY (DE) --")


### PR DESCRIPTION
## Summary
- fix the /print-report log output to use safe quoting for the routing reason field

## Testing
- python -m compileall app.py
- uvicorn app:app --host 127.0.0.1 --port 8081

------
https://chatgpt.com/codex/tasks/task_e_68e2db5c63a48330b0928a41fc1682ab